### PR TITLE
#BE-1619 Bump osx-serial-generator submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ LABEL maintainer='https://twitter.com/sickcodes <https://sick.codes>'
 SHELL ["/bin/bash", "-c"]
 
 RUN echo 'Server=https://archive.archlinux.org/repos/2022/04/21/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+RUN cp /etc/pacman.conf /etc/pacman.conf.old && \
+  sed -i 's/Required DatabaseOptional/Optional TrustAll/g' /etc/pacman.conf && \
+  { diff /etc/pacman.conf.old /etc/pacman.conf || true; }
 RUN yes | pacman -Syyuu
 
 # change disk size here or add during build, e.g. --build-arg VERSION=10.14.5 --build-arg SIZE=50G


### PR DESCRIPTION
See PR https://github.com/appcircleio/osx-serial-generator/pull/1 for the  details.

It updates `osx-serial-generator` to the version that should fix [BE-1619](https://linear.app/appcircle/issue/BE-1619/manuf-404-not-found-or-intel-pool).

___

**Update:** Since we pinned the Arch linux repository to a specific date, some expired signatures are breaking docker image build.
```txt
error: linux-api-headers: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/linux-api-headers-5.16.8-1-any.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: glibc: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/glibc-2.35-3-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: gcc-libs: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/gcc-libs-11.2.0-4-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: libelf: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/libelf-0.186-5-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: binutils: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/binutils-2.38-4-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: gcc: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/gcc-11.2.0-4-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: libtool: signature from "Frederik Schwan <frederik.schwan@linux.com>" is unknown trust
:: File /var/cache/pacman/pkg/libtool-2.4.7-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] y
error: failed to commit transaction (invalid or corrupted package)
```
So, I configured pacman to trust all existing (old) signatures. (`/etc/pacman.conf`)

```diff
< SigLevel    = Required DatabaseOptional
---
> SigLevel    = Optional TrustAll
```
See details in these resources: [ref-1](https://www.reddit.com/r/archlinux/comments/zaw8lo/expired_signature_issue_with_frederik_schwan/) [ref-2](https://bbs.archlinux.org/viewtopic.php?id=282796)

Now, I can build `macos` base image (`v1.1`) with the command below:

```bash
docker build -t docker-osx:macos --no-cache=true .
```